### PR TITLE
Changed required packages to generic stable Linux kernel

### DIFF
--- a/install-packages.txt
+++ b/install-packages.txt
@@ -8,7 +8,7 @@ ifupdown
 iproute2
 iptables
 iputils-ping
-linux-image-4.19.0-6-amd64
+linux-image-amd64
 live-boot
 net-tools
 openssh-server


### PR DESCRIPTION
Thanks for the great project.
This change requires the latest stable Linux kernel instead of the specific 4.19.0.6-amd64 version which is no longer supported.